### PR TITLE
Fixes #728: Fix topology label colors in dark mode

### DIFF
--- a/netbox_topology_views/static_dev/js/home.js
+++ b/netbox_topology_views/static_dev/js/home.js
@@ -611,7 +611,7 @@ const observer = new MutationObserver((mutations) =>
     })
 )
 
-observer.observe(document.body, {
+observer.observe(document.documentElement, {
     attributes: true,
     attributeFilter: ['data-bs-theme']
 })


### PR DESCRIPTION
Fixes #728

Topology Views observes changes to `data-bs-theme` on `document.body`, while NetBox applies the theme attribute to the root "<html>" element.

As a result, the existing theme-switching logic does not detect the active NetBox theme correctly, causing topology node labels to remain black in dark mode.

This changes the MutationObserver target from `document.body` to `document.documentElement`.

The existing light/dark color handling is left unchanged.

Tested with:
- NetBox 4.6.x
- Topology Views 4.5.1
- Dark mode
- Light mode